### PR TITLE
using default_factory in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `ValueError` when starting viewer for the first time with default config.
+
 ### Removed
 
 

--- a/src/compas_notebook/config.py
+++ b/src/compas_notebook/config.py
@@ -19,7 +19,7 @@ class CameraConfig:
 @dataclass
 class ViewConfig:
     viewport: Literal["top", "perspective"] = "perspective"
-    background: Color = Color.from_hex("#eeeeee")
+    background: Color = field(default_factory=lambda: Color.from_hex("#eeeeee"))
     width: float = 1100
     height: float = 580
     show_grid: bool = True


### PR DESCRIPTION
Was getting `ValueError` when opening the viewer for the first time without any config.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
