### PR TITLE
coverage for all compas primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added support for `frames, circle, ellipse, vector, plane, curve, analystical surface primitives`
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added support for `frames, circle, ellipse, vector, plane, curve, analystical surface primitives`
+* Dot command added 
 
 ### Changed
 

--- a/notebooks/00_basics.ipynb
+++ b/notebooks/00_basics.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/notebooks/10_scene.ipynb
+++ b/notebooks/10_scene.ipynb
@@ -2,15 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,70 +18,23 @@
     "from compas.geometry import Vector\n",
     "from compas.geometry import SphericalSurface\n",
     "from compas.geometry import CylindricalSurface\n",
+    "from compas_notebook.geometry import Dot\n",
     "from compas_notebook.viewer import Viewer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "point = Point(-1, 2, 3)\n",
-    "vector = Vector(1, 1, 2)\n",
-    "plane = Plane([0, 0, -1], [0, 0, 1])\n",
-    "frame = Frame(point, [1, 0, 0], [0, 1, 0])\n",
-    "\n",
-    "line = Line([0, 0, 0], point)\n",
-    "cloud = Pointcloud.from_bounds(x=8, y=5, z=3, n=13)\n",
-    "polyline = Polyline(cloud.points)\n",
-    "\n",
-    "# quadric curves\n",
-    "circle = Circle(radius=1.5, frame=Frame([2, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
-    "ellipse = Ellipse(major=2.0, minor=1.0, frame=Frame([5, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
-    "\n",
-    "# Create analytical surfaces\n",
-    "sphere_surface = SphericalSurface(radius=1.5, frame=Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))\n",
-    "cylinder_surface = CylindricalSurface(radius=0.8, frame=Frame([3, 0, 0], [1, 0, 0], [0, 1, 0]))"
-   ]
+   "source": "point = Point(-1, 2, 3)\nvector = Vector(1, 1, 2)\nplane = Plane([0, 0, -1], [0, 0, 1])\nframe = Frame(point, [1, 0, 0], [0, 1, 0])\n\nline = Line([0, 0, 0], point)\ncloud = Pointcloud.from_bounds(x=8, y=5, z=3, n=13)\npolyline = Polyline(cloud.points)\n\n# quadric curves\ncircle = Circle(radius=1.5, frame=Frame([2, 0, 0], [0, 1, 0], [0, 0, 1]))\nellipse = Ellipse(major=2.0, minor=1.0, frame=Frame([5, 0, 0], [0, 1, 0], [0, 0, 1]))\n\n# Create analytical surfaces\nsphere_surface = SphericalSurface(radius=1.5, frame=Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))\ncylinder_surface = CylindricalSurface(radius=0.8, frame=Frame([3, 0, 0], [1, 0, 0], [0, 1, 0]))\n\n# Dot: text label at a point (constant screen size)\ndot = Dot([8, 5, 3], \"Corner\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d32833ac778148c0920dfa0e9b672076",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HBox(children=(Button(icon='search-plus', layout=Layout(height='32px', width='48px'), style=But…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "viewer = Viewer()\n",
-    "\n",
-    "viewer.scene.add(point, color=Color.red(), pointsize=0.3)\n",
-    "viewer.scene.add(line)\n",
-    "viewer.scene.add(frame)\n",
-    "viewer.scene.add(polyline, color=Color.blue())\n",
-    "viewer.scene.add(cloud, color=Color.green(), pointsize=0.3)\n",
-    "viewer.scene.add(circle, color=Color.red())\n",
-    "viewer.scene.add(ellipse, color=Color.green())\n",
-    "viewer.scene.add(vector)\n",
-    "viewer.scene.add(plane)\n",
-    "viewer.scene.add(sphere_surface, color=Color.cyan())\n",
-    "viewer.scene.add(cylinder_surface, color=Color.magenta())\n",
-    "\n",
-    "viewer.show()"
-   ]
+   "outputs": [],
+   "source": "viewer = Viewer()\n\nviewer.scene.add(point, color=Color.red(), pointsize=0.3)\nviewer.scene.add(line)\nviewer.scene.add(frame)\nviewer.scene.add(polyline, color=Color.blue())\nviewer.scene.add(cloud, color=Color.green(), pointsize=0.3)\nviewer.scene.add(circle, color=Color.red())\nviewer.scene.add(ellipse, color=Color.green())\nviewer.scene.add(vector)\nviewer.scene.add(plane)\nviewer.scene.add(sphere_surface, color=Color.cyan())\nviewer.scene.add(cylinder_surface, color=Color.magenta())\nviewer.scene.add(dot, color=Color.black())\n\nviewer.show()"
   }
  ],
  "metadata": {

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q compas_notebook"
+    "# /%pip install -q compas_notebook"
    ]
   },
   {
@@ -20,6 +20,7 @@
     "from compas.geometry import Point\n",
     "from compas.geometry import Pointcloud\n",
     "from compas.geometry import Polyline\n",
+    "from compas.geometry import Frame \n",
     "from compas_notebook.viewer import Viewer"
    ]
   },
@@ -33,7 +34,16 @@
     "\n",
     "point = Point(-1, 2, 3)\n",
     "line = Line([0, 0, 0], point)\n",
-    "polyline = Polyline(cloud.points)"
+    "polyline = Polyline(cloud.points)\n",
+    "\n",
+    "\n",
+    "frame = Frame(point, [1, 0, 0], [0, 1, 0])\n",
+    "\n",
+    "# x_line = Line(frame.point, frame.point+frame.xaxis)\n",
+    "# y_line = Line(frame.point, frame.point+frame.yaxis)\n",
+    "# z_line = Line(frame.point, frame.point+frame.zaxis)\n",
+    "\n",
+    "\n"
    ]
   },
   {
@@ -44,7 +54,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a55820df515f4eb0a67494e16869aac2",
+       "model_id": "60cefc1deea3458c9e1a390cdd0ea3ba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -61,6 +71,7 @@
     "\n",
     "viewer.scene.add(point, color=Color.red(), pointsize=0.3)\n",
     "viewer.scene.add(line)\n",
+    "viewer.scene.add(frame)\n",
     "viewer.scene.add(polyline, color=Color.blue())\n",
     "viewer.scene.add(cloud, color=Color.green(), pointsize=0.3)\n",
     "\n",
@@ -70,7 +81,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "compas2",
+   "display_name": "compas_opzuid",
    "language": "python",
    "name": "python3"
   },
@@ -84,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -2,22 +2,26 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from compas.colors import Color\n",
+    "from compas.geometry import Circle\n",
+    "from compas.geometry import Ellipse\n",
+    "from compas.geometry import Frame\n",
     "from compas.geometry import Line\n",
+    "from compas.geometry import Plane\n",
     "from compas.geometry import Point\n",
     "from compas.geometry import Pointcloud\n",
     "from compas.geometry import Polyline\n",
-    "from compas.geometry import Frame \n",
+    "from compas.geometry import Vector\n",
     "from compas_notebook.viewer import Viewer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,13 +43,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60cefc1deea3458c9e1a390cdd0ea3ba",
+       "model_id": "0498e1e0a2e3459480997d957fbfc9da",
        "version_major": 2,
        "version_minor": 0
       },
@@ -68,11 +72,78 @@
     "\n",
     "viewer.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# New Primitives\n",
+    "\n",
+    "Demonstration of recently added primitive support: Circle, Ellipse, Vector, and Plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create new primitives\n",
+    "circle = Circle(radius=1.5, frame=Frame([2, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
+    "ellipse = Ellipse(major=2.0, minor=1.0, frame=Frame([5, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
+    "vector = Vector(1, 1, 2)\n",
+    "plane = Plane([0, 0, -1], [0, 0, 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cac0c93ba69483fb0534923124dbe15",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(Button(icon='search-plus', layout=Layout(height='32px', width='48px'), style=But…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "viewer2 = Viewer()\n",
+    "\n",
+    "viewer2.scene.add(circle, color=Color.red())\n",
+    "viewer2.scene.add(ellipse, color=Color.green())\n",
+    "viewer2.scene.add(vector)\n",
+    "viewer2.scene.add(plane)\n",
+    "\n",
+    "viewer2.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "compas_opzuid",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -90,5 +161,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -2,15 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# /%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -2,42 +2,58 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "from compas.colors import Color\nfrom compas.geometry import Circle\nfrom compas.geometry import Ellipse\nfrom compas.geometry import Frame\nfrom compas.geometry import Line\nfrom compas.geometry import Plane\nfrom compas.geometry import Point\nfrom compas.geometry import Pointcloud\nfrom compas.geometry import Polyline\nfrom compas.geometry import Vector\nfrom compas.geometry import SphericalSurface\nfrom compas.geometry import CylindricalSurface\nfrom compas_notebook.viewer import Viewer"
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cloud = Pointcloud.from_bounds(x=8, y=5, z=3, n=13)\n",
-    "\n",
-    "point = Point(-1, 2, 3)\n",
-    "line = Line([0, 0, 0], point)\n",
-    "polyline = Polyline(cloud.points)\n",
-    "\n",
-    "\n",
-    "frame = Frame(point, [1, 0, 0], [0, 1, 0])\n",
-    "\n",
-    "# x_line = Line(frame.point, frame.point+frame.xaxis)\n",
-    "# y_line = Line(frame.point, frame.point+frame.yaxis)\n",
-    "# z_line = Line(frame.point, frame.point+frame.zaxis)\n",
-    "\n",
-    "\n"
+    "from compas.colors import Color\n",
+    "from compas.geometry import Circle\n",
+    "from compas.geometry import Ellipse\n",
+    "from compas.geometry import Frame\n",
+    "from compas.geometry import Line\n",
+    "from compas.geometry import Plane\n",
+    "from compas.geometry import Point\n",
+    "from compas.geometry import Pointcloud\n",
+    "from compas.geometry import Polyline\n",
+    "from compas.geometry import Vector\n",
+    "from compas.geometry import SphericalSurface\n",
+    "from compas.geometry import CylindricalSurface\n",
+    "from compas_notebook.viewer import Viewer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = Point(-1, 2, 3)\n",
+    "vector = Vector(1, 1, 2)\n",
+    "plane = Plane([0, 0, -1], [0, 0, 1])\n",
+    "frame = Frame(point, [1, 0, 0], [0, 1, 0])\n",
+    "\n",
+    "line = Line([0, 0, 0], point)\n",
+    "cloud = Pointcloud.from_bounds(x=8, y=5, z=3, n=13)\n",
+    "polyline = Polyline(cloud.points)\n",
+    "\n",
+    "# quadric curves\n",
+    "circle = Circle(radius=1.5, frame=Frame([2, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
+    "ellipse = Ellipse(major=2.0, minor=1.0, frame=Frame([5, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
+    "\n",
+    "# Create analytical surfaces\n",
+    "sphere_surface = SphericalSurface(radius=1.5, frame=Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))\n",
+    "cylinder_surface = CylindricalSurface(radius=0.8, frame=Frame([3, 0, 0], [1, 0, 0], [0, 1, 0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0498e1e0a2e3459480997d957fbfc9da",
+       "model_id": "d32833ac778148c0920dfa0e9b672076",
        "version_major": 2,
        "version_minor": 0
       },
@@ -57,100 +73,20 @@
     "viewer.scene.add(frame)\n",
     "viewer.scene.add(polyline, color=Color.blue())\n",
     "viewer.scene.add(cloud, color=Color.green(), pointsize=0.3)\n",
+    "viewer.scene.add(circle, color=Color.red())\n",
+    "viewer.scene.add(ellipse, color=Color.green())\n",
+    "viewer.scene.add(vector)\n",
+    "viewer.scene.add(plane)\n",
+    "viewer.scene.add(sphere_surface, color=Color.cyan())\n",
+    "viewer.scene.add(cylinder_surface, color=Color.magenta())\n",
     "\n",
     "viewer.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# New Primitives\n",
-    "\n",
-    "Demonstration of recently added primitive support: Circle, Ellipse, Vector, and Plane."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create new primitives\n",
-    "circle = Circle(radius=1.5, frame=Frame([2, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
-    "ellipse = Ellipse(major=2.0, minor=1.0, frame=Frame([5, 0, 0], [0, 1, 0], [0, 0, 1]))\n",
-    "vector = Vector(1, 1, 2)\n",
-    "plane = Plane([0, 0, -1], [0, 0, 1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3cac0c93ba69483fb0534923124dbe15",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HBox(children=(Button(icon='search-plus', layout=Layout(height='32px', width='48px'), style=But…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "viewer2 = Viewer()\n",
-    "\n",
-    "viewer2.scene.add(circle, color=Color.red())\n",
-    "viewer2.scene.add(ellipse, color=Color.green())\n",
-    "viewer2.scene.add(vector)\n",
-    "viewer2.scene.add(plane)\n",
-    "\n",
-    "viewer2.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "source": "# Surfaces\n\nAnalytical surfaces work out of the box.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "source": "# Create analytical surfaces\nsphere_surface = SphericalSurface(radius=1.5, frame=Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))\ncylinder_surface = CylindricalSurface(radius=0.8, frame=Frame([3, 0, 0], [1, 0, 0], [0, 1, 0]))",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "source": "viewer3 = Viewer()\n\nviewer3.scene.add(sphere_surface, color=Color.cyan())\nviewer3.scene.add(cylinder_surface, color=Color.magenta())\n\nviewer3.show()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "compas_opzuid",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/20_geometry.ipynb
+++ b/notebooks/20_geometry.ipynb
@@ -2,22 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from compas.colors import Color\n",
-    "from compas.geometry import Circle\n",
-    "from compas.geometry import Ellipse\n",
-    "from compas.geometry import Frame\n",
-    "from compas.geometry import Line\n",
-    "from compas.geometry import Plane\n",
-    "from compas.geometry import Point\n",
-    "from compas.geometry import Pointcloud\n",
-    "from compas.geometry import Polyline\n",
-    "from compas.geometry import Vector\n",
-    "from compas_notebook.viewer import Viewer"
-   ]
+   "source": "from compas.colors import Color\nfrom compas.geometry import Circle\nfrom compas.geometry import Ellipse\nfrom compas.geometry import Frame\nfrom compas.geometry import Line\nfrom compas.geometry import Plane\nfrom compas.geometry import Point\nfrom compas.geometry import Pointcloud\nfrom compas.geometry import Polyline\nfrom compas.geometry import Vector\nfrom compas.geometry import SphericalSurface\nfrom compas.geometry import CylindricalSurface\nfrom compas_notebook.viewer import Viewer"
   },
   {
    "cell_type": "code",
@@ -139,6 +127,25 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "# Surfaces\n\nAnalytical surfaces work out of the box.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Create analytical surfaces\nsphere_surface = SphericalSurface(radius=1.5, frame=Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))\ncylinder_surface = CylindricalSurface(radius=0.8, frame=Frame([3, 0, 0], [1, 0, 0], [0, 1, 0]))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "viewer3 = Viewer()\n\nviewer3.scene.add(sphere_surface, color=Color.cyan())\nviewer3.scene.add(cylinder_surface, color=Color.magenta())\n\nviewer3.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/notebooks/30_shapes.ipynb
+++ b/notebooks/30_shapes.ipynb
@@ -2,15 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/notebooks/60_breps.ipynb
+++ b/notebooks/60_breps.ipynb
@@ -2,23 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/notebooks/70_graphs.ipynb
+++ b/notebooks/70_graphs.ipynb
@@ -2,15 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/notebooks/80_groups.ipynb
+++ b/notebooks/80_groups.ipynb
@@ -2,23 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install -q compas_notebook"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],

--- a/src/compas_notebook/conversions/__init__.py
+++ b/src/compas_notebook/conversions/__init__.py
@@ -3,6 +3,7 @@ from .colors import color_to_threejs
 from .geometry import box_to_threejs
 from .geometry import cone_to_threejs
 from .geometry import cylinder_to_threejs
+from .geometry import dot_to_threejs
 from .geometry import line_to_threejs
 from .geometry import point_to_threejs
 from .geometry import pointcloud_to_threejs
@@ -26,6 +27,7 @@ __all__ = [
     "color_to_threejs",
     "cone_to_threejs",
     "cylinder_to_threejs",
+    "dot_to_threejs",
     "line_to_threejs",
     "nodes_and_edges_to_threejs",
     "nodes_to_threejs",

--- a/src/compas_notebook/conversions/geometry.py
+++ b/src/compas_notebook/conversions/geometry.py
@@ -1,3 +1,4 @@
+import re
 import numpy
 import pythreejs as three
 from compas.geometry import Box
@@ -8,9 +9,11 @@ from compas.geometry import Pointcloud
 from compas.geometry import Polyline
 from compas.geometry import Sphere
 from compas.geometry import Torus
+from compas.geometry import Frame
+from compas.geometry import Line
 
 
-def line_to_threejs(line: Point) -> three.BufferGeometry:
+def line_to_threejs(line: Line) -> three.BufferGeometry:
     """Convert a COMPAS line to PyThreeJS.
 
     Parameters
@@ -26,6 +29,39 @@ def line_to_threejs(line: Point) -> three.BufferGeometry:
     vertices = numpy.array([line.start, line.end], dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
+
+
+def frame_to_threejs(frame: Frame) -> list[three.BufferGeometry]:
+    """Convert a COMPAS frame to PyThreeJS.
+
+    Parameters
+    ----------
+    frame : :class:`compas.geometry.Frame`
+        The frame to convert.
+
+    Returns
+    -------
+    list[three.BufferGeometry]
+
+    """
+
+    # create lines for each axis
+    _x_line = Line(frame.point, frame.point + frame.xaxis)
+    _y_line = Line(frame.point, frame.point + frame.yaxis)
+    _z_line = Line(frame.point, frame.point + frame.zaxis)
+
+    # convert lines to threejs vertex buffers
+    xline_verts = line_to_threejs(_x_line)
+    yline_verts = line_to_threejs(_y_line)
+    zline_verts = line_to_threejs(_z_line)
+
+    # convert from vertex buffers to line objects
+    xline_lines = three.Line(xline_verts, three.LineBasicMaterial(color="red"))
+    yline_lines = three.Line(yline_verts, three.LineBasicMaterial(color="green"))
+    zline_lines = three.Line(zline_verts, three.LineBasicMaterial(color="blue"))
+
+    result = [xline_lines, yline_lines, zline_lines]
+    return result
 
 
 def point_to_threejs(point: Point) -> three.SphereGeometry:

--- a/src/compas_notebook/conversions/geometry.py
+++ b/src/compas_notebook/conversions/geometry.py
@@ -1,4 +1,5 @@
 import re
+import math
 import numpy
 import pythreejs as three
 from compas.geometry import Box
@@ -17,6 +18,8 @@ from compas.geometry import Sphere
 from compas.geometry import Surface
 from compas.geometry import Torus
 from compas.geometry import Vector
+from compas_notebook.conversions.meshes import vertices_and_edges_to_threejs
+from compas_notebook.conversions.meshes import vertices_and_faces_to_threejs
 
 
 def line_to_threejs(line: Line) -> three.BufferGeometry:
@@ -32,7 +35,7 @@ def line_to_threejs(line: Line) -> three.BufferGeometry:
     :class:`three.BufferGeometry`
 
     """
-    vertices = numpy.array([line.start, line.end], dtype=numpy.float32)
+    vertices = numpy.array([line.start, line.end], dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -53,8 +56,8 @@ def frame_to_threejs(frame: Frame) -> list[three.BufferGeometry]:
 
     # create lines for each axis
     _x_line = Line(frame.point, frame.point + frame.xaxis)
-    _y_line = Line(frame.point, frame.point + frame.yaxis)
-    _z_line = Line(frame.point, frame.point + frame.zaxis)
+    _y_line = Line.from_point_and_vector(frame.point, frame.yaxis)
+    _z_line = Line.from_point_and_vector(frame.point, frame.zaxis)
 
     # convert lines to threejs vertex buffers
     xline_verts = line_to_threejs(_x_line)
@@ -90,7 +93,7 @@ def point_to_threejs(point: Point) -> three.SphereGeometry:
     BufferGeometry(...)
 
     """
-    vertices = numpy.array([point], dtype=numpy.float32)
+    vertices = numpy.array([point], dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -112,7 +115,7 @@ def pointcloud_to_threejs(pointcloud: Pointcloud) -> three.SphereGeometry:
     >>>
 
     """
-    vertices = numpy.array(pointcloud.points, dtype=numpy.float32)
+    vertices = numpy.array(pointcloud.points, dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -130,7 +133,7 @@ def polyline_to_threejs(polyline: Polyline) -> three.BufferGeometry:
     :class:`three.BufferGeometry`
 
     """
-    vertices = numpy.array(polyline.points, dtype=numpy.float32)
+    vertices = numpy.array(polyline.points, dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -150,11 +153,10 @@ def circle_to_threejs(circle: Circle, max_angle: float = 5.0) -> three.BufferGeo
     :class:`three.BufferGeometry`
 
     """
-    import math
 
     n = max(8, int(math.ceil(360.0 / max_angle)))
     polyline = circle.to_polyline(n=n)
-    vertices = numpy.array(polyline.points, dtype=numpy.float32)
+    vertices = numpy.array(polyline.points, dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -174,11 +176,9 @@ def ellipse_to_threejs(ellipse: Ellipse, max_angle: float = 5.0) -> three.Buffer
     :class:`three.BufferGeometry`
 
     """
-    import math
-
     n = max(8, int(math.ceil(360.0 / max_angle)))
     polyline = ellipse.to_polyline(n=n)
-    vertices = numpy.array(polyline.points, dtype=numpy.float32)
+    vertices = numpy.array(polyline.points, dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -326,7 +326,7 @@ def curve_to_threejs(curve: Curve, resolution: int = 100) -> three.BufferGeometr
 
     """
     polyline = curve.to_polyline(n=resolution)
-    vertices = numpy.array(polyline.points, dtype=numpy.float32)
+    vertices = numpy.array(polyline.points, dtype=numpy.float64)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -349,9 +349,6 @@ def surface_to_threejs(surface: Surface, resolution_u: int = 20, resolution_v: i
         Mesh and edge visualization.
 
     """
-    from compas_notebook.conversions.meshes import vertices_and_edges_to_threejs
-    from compas_notebook.conversions.meshes import vertices_and_faces_to_threejs
-
     vertices, faces = surface.to_vertices_and_faces(nu=resolution_u, nv=resolution_v)
 
     # Create faces

--- a/src/compas_notebook/conversions/geometry.py
+++ b/src/compas_notebook/conversions/geometry.py
@@ -18,6 +18,7 @@ from compas.geometry import Sphere
 from compas.geometry import Surface
 from compas.geometry import Torus
 from compas.geometry import Vector
+from compas_notebook.geometry import Dot
 from compas_notebook.conversions.meshes import vertices_and_edges_to_threejs
 from compas_notebook.conversions.meshes import vertices_and_faces_to_threejs
 
@@ -35,7 +36,7 @@ def line_to_threejs(line: Line) -> three.BufferGeometry:
     :class:`three.BufferGeometry`
 
     """
-    vertices = numpy.array([line.start, line.end], dtype=numpy.float64)
+    vertices = numpy.array([line.start, line.end], dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -93,7 +94,7 @@ def point_to_threejs(point: Point) -> three.SphereGeometry:
     BufferGeometry(...)
 
     """
-    vertices = numpy.array([point], dtype=numpy.float64)
+    vertices = numpy.array([point], dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -115,7 +116,7 @@ def pointcloud_to_threejs(pointcloud: Pointcloud) -> three.SphereGeometry:
     >>>
 
     """
-    vertices = numpy.array(pointcloud.points, dtype=numpy.float64)
+    vertices = numpy.array(pointcloud.points, dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -133,7 +134,7 @@ def polyline_to_threejs(polyline: Polyline) -> three.BufferGeometry:
     :class:`three.BufferGeometry`
 
     """
-    vertices = numpy.array(polyline.points, dtype=numpy.float64)
+    vertices = numpy.array(polyline.points, dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -156,7 +157,7 @@ def circle_to_threejs(circle: Circle, max_angle: float = 5.0) -> three.BufferGeo
 
     n = max(8, int(math.ceil(360.0 / max_angle)))
     polyline = circle.to_polyline(n=n)
-    vertices = numpy.array(polyline.points, dtype=numpy.float64)
+    vertices = numpy.array(polyline.points, dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -178,7 +179,7 @@ def ellipse_to_threejs(ellipse: Ellipse, max_angle: float = 5.0) -> three.Buffer
     """
     n = max(8, int(math.ceil(360.0 / max_angle)))
     polyline = ellipse.to_polyline(n=n)
-    vertices = numpy.array(polyline.points, dtype=numpy.float64)
+    vertices = numpy.array(polyline.points, dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -326,7 +327,7 @@ def curve_to_threejs(curve: Curve, resolution: int = 100) -> three.BufferGeometr
 
     """
     polyline = curve.to_polyline(n=resolution)
-    vertices = numpy.array(polyline.points, dtype=numpy.float64)
+    vertices = numpy.array(polyline.points, dtype=numpy.float32)
     geometry = three.BufferGeometry(attributes={"position": three.BufferAttribute(vertices, normalized=False)})
     return geometry
 
@@ -505,3 +506,34 @@ def torus_to_threejs(torus: Torus) -> three.TorusGeometry:
         radialSegments=64,
         tubularSegments=32,
     )
+
+
+def dot_to_threejs(dot: Dot, fontsize: int = 48, color: str = "white") -> three.Sprite:
+    """Convert a COMPAS Dot to PyThreeJS Sprite.
+
+    The sprite maintains constant screen size regardless of zoom level.
+
+    Parameters
+    ----------
+    dot : :class:`compas_notebook.geometry.Dot`
+        The dot to convert.
+    fontsize : int, optional
+        Font size for the text texture.
+    color : str, optional
+        Text color.
+
+    Returns
+    -------
+    :class:`three.Sprite`
+        A sprite with text texture positioned at the dot location.
+
+    """
+    texture = three.TextTexture(string=dot.text, size=fontsize, color=color, squareTexture=False)
+    material = three.SpriteMaterial(map=texture, sizeAttenuation=False, transparent=True)
+    sprite = three.Sprite(material=material)
+    sprite.position = [dot.point.x, dot.point.y, dot.point.z]
+    # scale based on text length - roughly 0.6 width per character
+    aspect = len(dot.text) * 0.6
+    scale = 0.025
+    sprite.scale = [scale * aspect, scale, 1]
+    return sprite

--- a/src/compas_notebook/geometry/__init__.py
+++ b/src/compas_notebook/geometry/__init__.py
@@ -1,0 +1,1 @@
+from .dot import Dot

--- a/src/compas_notebook/geometry/__init__.py
+++ b/src/compas_notebook/geometry/__init__.py
@@ -1,1 +1,3 @@
 from .dot import Dot
+
+__all__ = ["Dot",] # under protest

--- a/src/compas_notebook/geometry/dot.py
+++ b/src/compas_notebook/geometry/dot.py
@@ -1,0 +1,108 @@
+from compas.geometry import Geometry
+from compas.geometry import Point
+
+
+class Dot(Geometry):
+    """A dot is text displayed at a point location.
+
+    The dot maintains constant screen size regardless of zoom level,
+    similar to Rhino's Dot command.
+
+    Parameters
+    ----------
+    point : :class:`compas.geometry.Point` | list[float]
+        The location of the dot.
+    text : str
+        The text to display.
+    name : str, optional
+        The name of the dot.
+
+    Attributes
+    ----------
+    point : :class:`compas.geometry.Point`
+        The location of the dot.
+    text : str
+        The text to display.
+
+    Examples
+    --------
+    >>> from compas.geometry import Point
+    >>> from compas_notebook.geometry import Dot
+    >>> dot = Dot([0, 0, 0], "Hello")
+    >>> dot.point
+    Point(x=0.000, y=0.000, z=0.000)
+    >>> dot.text
+    'Hello'
+
+    """
+
+    DATASCHEMA = {
+        "type": "object",
+        "properties": {
+            "point": Point.DATASCHEMA,
+            "text": {"type": "string"},
+        },
+        "required": ["point", "text"],
+    }
+
+    @property
+    def __data__(self):
+        return {
+            "point": self._point.__data__,
+            "text": self._text,
+        }
+
+    @classmethod
+    def __from_data__(cls, data):
+        return cls(
+            point=Point.__from_data__(data["point"]),
+            text=data["text"],
+        )
+
+    def __init__(self, point, text, name=None):
+        super().__init__(name=name)
+        self._point = None
+        self._text = None
+        self.point = point
+        self.text = text
+
+    def __repr__(self):
+        return f"Dot({self.point!r}, {self.text!r})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Dot):
+            return False
+        return self.point == other.point and self.text == other.text
+
+    @property
+    def point(self):
+        return self._point
+
+    @point.setter
+    def point(self, value):
+        if not isinstance(value, Point):
+            value = Point(*value)
+        self._point = value
+
+    @property
+    def text(self):
+        return self._text
+
+    @text.setter
+    def text(self, value):
+        self._text = str(value)
+
+    def transform(self, transformation):
+        """Transform the dot.
+
+        Parameters
+        ----------
+        transformation : :class:`compas.geometry.Transformation`
+            The transformation to apply.
+
+        Returns
+        -------
+        None
+
+        """
+        self.point.transform(transformation)

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -10,17 +10,23 @@ from compas.scene import register
 from compas.geometry import Box
 from compas.geometry import Brep
 from compas.geometry import Capsule
+from compas.geometry import Circle
 from compas.geometry import Cone
+from compas.geometry import Curve
 from compas.geometry import Cylinder
-from compas.geometry import Line
+from compas.geometry import Ellipse
 from compas.geometry import Frame
+from compas.geometry import Line
+from compas.geometry import Plane
 from compas.geometry import Point
 from compas.geometry import Pointcloud
 from compas.geometry import Polygon
 from compas.geometry import Polyhedron
 from compas.geometry import Polyline
 from compas.geometry import Sphere
+from compas.geometry import Surface
 from compas.geometry import Torus
+from compas.geometry import Vector
 
 from compas.datastructures import Graph
 from compas.datastructures import Mesh
@@ -32,22 +38,27 @@ from .sceneobject import ThreeSceneObject
 from .boxobject import ThreeBoxObject
 from .brepobject import ThreeBrepObject
 from .capsuleobject import ThreeCapsuleObject
+from .circleobject import ThreeCircleObject
 from .coneobject import ThreeConeObject
+from .curveobject import ThreeCurveObject
 from .cylinderobject import ThreeCylinderObject
+from .ellipseobject import ThreeEllipseObject
+from .frameobject import ThreeFrameObject
+from .groupobject import ThreeGroupObject
 from .lineobject import ThreeLineObject
+from .planeobject import ThreePlaneObject
 from .pointobject import ThreePointObject
 from .pointcloudobject import ThreePointcloudObject
 from .polygonobject import ThreePolygonObject
 from .polyhedronobject import ThreePolyhedronObject
 from .polylineobject import ThreePolylineObject
 from .sphereobject import ThreeSphereObject
+from .surfaceobject import ThreeSurfaceObject
 from .torusobject import ThreeTorusObject
+from .vectorobject import ThreeVectorObject
 
 from .graphobject import ThreeGraphObject
 from .meshobject import ThreeMeshObject
-
-from .groupobject import ThreeGroupObject
-from .frameobject import ThreeFrameObject
 
 
 @plugin(category="drawing-utils", pluggable_name="clear", requires=["pythreejs"])
@@ -74,19 +85,25 @@ def register_scene_objects():
     register(Box, ThreeBoxObject, context="Notebook")
     register(Brep, ThreeBrepObject, context="Notebook")
     register(Capsule, ThreeCapsuleObject, context="Notebook")
+    register(Circle, ThreeCircleObject, context="Notebook")
     register(Cone, ThreeConeObject, context="Notebook")
+    register(Curve, ThreeCurveObject, context="Notebook")
     register(Cylinder, ThreeCylinderObject, context="Notebook")
-    register(Graph, ThreeGraphObject, context="Notebook")
+    register(Ellipse, ThreeEllipseObject, context="Notebook")
     register(Frame, ThreeFrameObject, context="Notebook")
+    register(Graph, ThreeGraphObject, context="Notebook")
     register(Line, ThreeLineObject, context="Notebook")
+    register(Mesh, ThreeMeshObject, context="Notebook")
+    register(Plane, ThreePlaneObject, context="Notebook")
     register(Point, ThreePointObject, context="Notebook")
     register(Pointcloud, ThreePointcloudObject, context="Notebook")
     register(Polygon, ThreePolygonObject, context="Notebook")
     register(Polyhedron, ThreePolyhedronObject, context="Notebook")
     register(Polyline, ThreePolylineObject, context="Notebook")
     register(Sphere, ThreeSphereObject, context="Notebook")
+    register(Surface, ThreeSurfaceObject, context="Notebook")
     register(Torus, ThreeTorusObject, context="Notebook")
-    register(Mesh, ThreeMeshObject, context="Notebook")
+    register(Vector, ThreeVectorObject, context="Notebook")
     register(list, ThreeGroupObject, context="Notebook")
 
 # # yuck java

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -28,6 +28,8 @@ from compas.geometry import Surface
 from compas.geometry import Torus
 from compas.geometry import Vector
 
+from compas_notebook.geometry import Dot
+
 from compas.datastructures import Graph
 from compas.datastructures import Mesh
 
@@ -42,6 +44,7 @@ from .circleobject import ThreeCircleObject
 from .coneobject import ThreeConeObject
 from .curveobject import ThreeCurveObject
 from .cylinderobject import ThreeCylinderObject
+from .dotobject import ThreeDotObject
 from .ellipseobject import ThreeEllipseObject
 from .frameobject import ThreeFrameObject
 from .groupobject import ThreeGroupObject
@@ -89,6 +92,7 @@ def register_scene_objects():
     register(Cone, ThreeConeObject, context="Notebook")
     register(Curve, ThreeCurveObject, context="Notebook")
     register(Cylinder, ThreeCylinderObject, context="Notebook")
+    register(Dot, ThreeDotObject, context="Notebook")
     register(Ellipse, ThreeEllipseObject, context="Notebook")
     register(Frame, ThreeFrameObject, context="Notebook")
     register(Graph, ThreeGraphObject, context="Notebook")

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -13,6 +13,7 @@ from compas.geometry import Capsule
 from compas.geometry import Cone
 from compas.geometry import Cylinder
 from compas.geometry import Line
+from compas.geometry import Frame
 from compas.geometry import Point
 from compas.geometry import Pointcloud
 from compas.geometry import Polygon
@@ -46,6 +47,7 @@ from .graphobject import ThreeGraphObject
 from .meshobject import ThreeMeshObject
 
 from .groupobject import ThreeGroupObject
+from .frameobject import ThreeFrameObject
 
 
 @plugin(category="drawing-utils", pluggable_name="clear", requires=["pythreejs"])
@@ -75,6 +77,7 @@ def register_scene_objects():
     register(Cone, ThreeConeObject, context="Notebook")
     register(Cylinder, ThreeCylinderObject, context="Notebook")
     register(Graph, ThreeGraphObject, context="Notebook")
+    register(Frame, ThreeFrameObject, context="Notebook")
     register(Line, ThreeLineObject, context="Notebook")
     register(Point, ThreePointObject, context="Notebook")
     register(Pointcloud, ThreePointcloudObject, context="Notebook")
@@ -86,20 +89,20 @@ def register_scene_objects():
     register(Mesh, ThreeMeshObject, context="Notebook")
     register(list, ThreeGroupObject, context="Notebook")
 
-
-__all__ = [
-    "NotebookScene",
-    "ThreeBoxObject",
-    "ThreeCapsuleObject",
-    "ThreeConeObject",
-    "ThreeCylinderObject",
-    "ThreeGraphObject",
-    "ThreePointObject",
-    "ThreePointcloudObject",
-    "ThreePolygonObject",
-    "ThreePolyhedronObject",
-    "ThreePolylineObject",
-    "ThreeSceneObject",
-    "ThreeSphereObject",
-    "ThreeTorusObject",
-]
+# # yuck java
+# __all__ = [
+#     "NotebookScene",
+#     "ThreeBoxObject",
+#     "ThreeCapsuleObject",
+#     "ThreeConeObject",
+#     "ThreeCylinderObject",
+#     "ThreeGraphObject",
+#     "ThreePointObject",
+#     "ThreePointcloudObject",
+#     "ThreePolygonObject",
+#     "ThreePolyhedronObject",
+#     "ThreePolylineObject",
+#     "ThreeSceneObject",
+#     "ThreeSphereObject",
+#     "ThreeTorusObject",
+# ]

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -106,20 +106,3 @@ def register_scene_objects():
     register(Vector, ThreeVectorObject, context="Notebook")
     register(list, ThreeGroupObject, context="Notebook")
 
-# # yuck java
-# __all__ = [
-#     "NotebookScene",
-#     "ThreeBoxObject",
-#     "ThreeCapsuleObject",
-#     "ThreeConeObject",
-#     "ThreeCylinderObject",
-#     "ThreeGraphObject",
-#     "ThreePointObject",
-#     "ThreePointcloudObject",
-#     "ThreePolygonObject",
-#     "ThreePolyhedronObject",
-#     "ThreePolylineObject",
-#     "ThreeSceneObject",
-#     "ThreeSphereObject",
-#     "ThreeTorusObject",
-# ]

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 """This package provides scene object plugins for visualising COMPAS objects in Jupyter Notebooks using three.
 When working in a notebook, :class:`compas.scene.SceneObject`
 will automatically use the corresponding PyThreeJS scene object for each COMPAS object type.
@@ -110,29 +111,3 @@ def register_scene_objects():
     register(Vector, ThreeVectorObject, context="Notebook")
     register(list, ThreeGroupObject, context="Notebook")
 
-
-_ = [ 
-    "Box",
-    "Brep",
-    "Capsule",
-    "Circle",
-    "Cone",
-    "Curve",
-    "Cylinder",
-    "Dot",
-    "Ellipse",
-    "Frame",
-    "Graph",
-    "Line",
-    "Mesh",
-    "Plane",
-    "Point",
-    "Pointcloud",
-    "Polygon",
-    "Polyhedron",
-    "Polyline",
-    "Sphere",
-    "Surface",
-    "Torus",
-    "Vector",
-]

--- a/src/compas_notebook/scene/__init__.py
+++ b/src/compas_notebook/scene/__init__.py
@@ -110,3 +110,29 @@ def register_scene_objects():
     register(Vector, ThreeVectorObject, context="Notebook")
     register(list, ThreeGroupObject, context="Notebook")
 
+
+_ = [ 
+    "Box",
+    "Brep",
+    "Capsule",
+    "Circle",
+    "Cone",
+    "Curve",
+    "Cylinder",
+    "Dot",
+    "Ellipse",
+    "Frame",
+    "Graph",
+    "Line",
+    "Mesh",
+    "Plane",
+    "Point",
+    "Pointcloud",
+    "Polygon",
+    "Polyhedron",
+    "Polyline",
+    "Sphere",
+    "Surface",
+    "Torus",
+    "Vector",
+]

--- a/src/compas_notebook/scene/circleobject.py
+++ b/src/compas_notebook/scene/circleobject.py
@@ -1,0 +1,26 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import circle_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeCircleObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing circles."""
+
+    def draw(self) -> list[three.Line]:
+        """Draw the circle as a discretized polyline.
+
+        Returns
+        -------
+        list[three.Line]
+            List of pythreejs objects created.
+
+        """
+        geometry = circle_to_threejs(self.geometry)
+        line = three.LineLoop(geometry, three.LineBasicMaterial(color=self.contrastcolor.hex))
+
+        self._guids = [line]
+
+        return self.guids

--- a/src/compas_notebook/scene/curveobject.py
+++ b/src/compas_notebook/scene/curveobject.py
@@ -1,0 +1,26 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import curve_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeCurveObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing curves."""
+
+    def draw(self) -> list[three.Line]:
+        """Draw the curve as discretized polyline.
+
+        Returns
+        -------
+        list[three.Line]
+            List of pythreejs objects created.
+
+        """
+        geometry = curve_to_threejs(self.geometry)
+        line = three.Line(geometry, three.LineBasicMaterial(color=self.contrastcolor.hex))
+
+        self._guids = [line]
+
+        return self.guids

--- a/src/compas_notebook/scene/dotobject.py
+++ b/src/compas_notebook/scene/dotobject.py
@@ -1,0 +1,30 @@
+from compas.colors import Color
+from compas.scene import GeometryObject
+from compas.scene.descriptors.color import ColorAttribute
+
+from compas_notebook.conversions import dot_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeDotObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing a dot (text at a point)."""
+
+    color = ColorAttribute(default=Color.black())
+
+    def __init__(self, fontsize=256, **kwargs):
+        super().__init__(**kwargs)
+        self.fontsize = fontsize
+
+    def draw(self):
+        """Draw the dot associated with the scene object.
+
+        Returns
+        -------
+        list[three.Sprite]
+            List of pythreejs objects created.
+
+        """
+        sprite = dot_to_threejs(self.geometry, fontsize=self.fontsize, color=self.color.hex)
+        self._guids = [sprite]
+        return self.guids

--- a/src/compas_notebook/scene/ellipseobject.py
+++ b/src/compas_notebook/scene/ellipseobject.py
@@ -1,0 +1,26 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import ellipse_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeEllipseObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing ellipses."""
+
+    def draw(self) -> list[three.Line]:
+        """Draw the ellipse as a discretized polyline.
+
+        Returns
+        -------
+        list[three.Line]
+            List of pythreejs objects created.
+
+        """
+        geometry = ellipse_to_threejs(self.geometry)
+        line = three.LineLoop(geometry, three.LineBasicMaterial(color=self.contrastcolor.hex))
+
+        self._guids = [line]
+
+        return self.guids

--- a/src/compas_notebook/scene/frameobject.py
+++ b/src/compas_notebook/scene/frameobject.py
@@ -1,0 +1,25 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import frame_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeFrameObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing frames"""
+
+    def draw(self):
+        """Draw the frame associated with the scene object as a set of lines: x-axis in red, y-axis in green, z-axis in blue.
+
+        Returns
+        -------
+        list[three.Line]
+            List of pythreejs objects created.
+
+        """
+
+
+        self._guids = frame_to_threejs(self.geometry)
+
+        return self.guids

--- a/src/compas_notebook/scene/lineobject.py
+++ b/src/compas_notebook/scene/lineobject.py
@@ -9,8 +9,8 @@ from .sceneobject import ThreeSceneObject
 class ThreeLineObject(ThreeSceneObject, GeometryObject):
     """Scene object for drawing line."""
 
-    def draw(self):
-        """Draw the line associated with the scene object.
+    def draw(self)-> list[three.Line]:
+        """Draw the frame associated with the scene object.
 
         Returns
         -------

--- a/src/compas_notebook/scene/planeobject.py
+++ b/src/compas_notebook/scene/planeobject.py
@@ -1,0 +1,23 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import plane_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreePlaneObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing planes as grids."""
+
+    def draw(self) -> list[three.Object3D]:
+        """Draw the plane as a grid.
+
+        Returns
+        -------
+        list[three.Object3D]
+            List of pythreejs objects created.
+
+        """
+        self._guids = plane_to_threejs(self.geometry)
+
+        return self.guids

--- a/src/compas_notebook/scene/surfaceobject.py
+++ b/src/compas_notebook/scene/surfaceobject.py
@@ -1,0 +1,23 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import surface_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeSurfaceObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing surfaces."""
+
+    def draw(self) -> list[three.Object3D]:
+        """Draw the surface as mesh with edges.
+
+        Returns
+        -------
+        list[three.Object3D]
+            List of pythreejs objects created.
+
+        """
+        self._guids = surface_to_threejs(self.geometry)
+
+        return self.guids

--- a/src/compas_notebook/scene/vectorobject.py
+++ b/src/compas_notebook/scene/vectorobject.py
@@ -1,0 +1,23 @@
+import pythreejs as three
+from compas.scene import GeometryObject
+
+from compas_notebook.conversions.geometry import vector_to_threejs
+
+from .sceneobject import ThreeSceneObject
+
+
+class ThreeVectorObject(ThreeSceneObject, GeometryObject):
+    """Scene object for drawing vectors as arrows."""
+
+    def draw(self) -> list[three.Object3D]:
+        """Draw the vector as arrow (line + cone head).
+
+        Returns
+        -------
+        list[three.Object3D]
+            List of pythreejs objects created.
+
+        """
+        self._guids = vector_to_threejs(self.geometry)
+
+        return self.guids


### PR DESCRIPTION
  ## Summary
  - removes problematic `%pip install -q compas_notebook` cell conflicting with dev mode (`pip install -e .`)
  - adds support for circle, ellipse, vector, plane, curve, surface primitives
  - adds analytical surface examples (spherical, cylindrical work without plugin)

  ## Changes
  - removes pip install cell from all example notebooks (7 files)
  - adds 6 new scene objects: CircleObject, EllipseObject, VectorObject, PlaneObject, CurveObject, SurfaceObject
  - extends geometry converters with angular resolution for circles/ellipses
  - vector rendered as arrow with cone head
  - plane shown as grid
  - curve/surface discretization (requires nurbs plugin for creation)
  - updates geometry notebook with surface examples
